### PR TITLE
fix(login-signup): update CORS and auth routes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,14 +18,13 @@ import { depositRouter } from "./modules/deposit/deposit.routes";
 const app = express();
 const server = http.createServer(app);
 
-app.use(cors());
 app.use(express.json());
 app.use(cookieParser());
 app.use(cors({ origin: process.env.FRONTEND_URL, credentials: true }));
 
 // Public routes
-app.use("/api/auth/register", SignUp);
-app.use("/api/auth/login", SignIn);
+app.post("/api/auth/register", SignUp);
+app.post("/api/auth/login", SignIn);
 
 // Routes
 app.use("/api/history", historyRoutes);


### PR DESCRIPTION
What changed: In crypto-pilot-be/src/server.ts, CORS is now configured with env.FRONTEND_URL and credentials: true, and the auth endpoints are explicitly registered as POST routes (/api/auth/register, /api/auth/login) instead of using app.use.

<img width="1440" height="781" alt="Screenshot 2025-12-26 at 10 17 16 PM" src="https://github.com/user-attachments/assets/b6ba91e1-f1ae-44b1-a0f6-99caa8fde091" />
<img width="1440" height="784" alt="Screenshot 2025-12-26 at 10 17 06 PM" src="https://github.com/user-attachments/assets/e5385954-f806-4190-807d-279a42f59c79" />
