### PR TITLE
fix: change frontend port & update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 node_modules
 dist
 .git
-.env
 .DS_Store
 coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../crypto-pilot-fe
       dockerfile: Dockerfile
     ports:
-      - "3002:3000"
+      - "3003:3000"
     env_file:
       - ../crypto-pilot-fe/.env
     depends_on:


### PR DESCRIPTION
This pull request makes minor updates to the Docker configuration for the frontend service. The most notable change is the update of the port mapping for the frontend container.

*Docker configuration updates:*

* Changed the frontend service port mapping in `docker-compose.yml` from `3002:3000` to `3003:3000`, which affects how the service is accessed locally.
* Removed `.env` from `.dockerignore`, allowing the `.env` file to be included in the Docker build context.